### PR TITLE
move tests and Debug out of nightly flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,10 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#![cfg_attr(feature = "nightly", feature(iter_order))]
 
 use std::borrow::Borrow;
-#[cfg(feature = "nightly")] use std::cmp::Ordering;
-#[cfg(feature = "nightly")] use std::fmt::{self, Debug};
+use std::cmp::Ordering;
+use std::fmt::{self, Debug};
 use std::hash::{self, Hash};
 use std::iter::{self, Map};
 use std::mem;
@@ -242,7 +241,6 @@ impl<K:Eq,V> LinearMap<K,V> {
     }
 }
 
-#[cfg(feature = "nightly")]
 impl<K, V> Debug for LinearMap<K, V> where K: Eq + Debug, V: Debug {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
@@ -278,24 +276,20 @@ impl<'a, K, V, Q: ?Sized> ops::Index<&'a Q> for LinearMap<K, V> where K: Eq + Bo
     fn index(&self, key: &'a Q) -> &V { self.get(key).expect("key not found") }
 }
 
-#[cfg(feature = "nightly")]
 impl<K, V> PartialEq for LinearMap<K, V> where K: Eq, V: PartialEq {
-    fn eq(&self, other: &Self) -> bool { iter::order::eq(self.iter(), other.iter()) }
+    fn eq(&self, other: &Self) -> bool { self.iter().eq(other.iter()) }
 }
 
-#[cfg(feature = "nightly")]
 impl<K, V> Eq for LinearMap<K, V> where K: Eq, V: Eq {}
 
-#[cfg(feature = "nightly")]
 impl<K, V> PartialOrd for LinearMap<K, V> where K: Eq + PartialOrd, V: PartialOrd {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        iter::order::partial_cmp(self.iter(), other.iter())
+        self.iter().partial_cmp(other.iter())
     }
 }
 
-#[cfg(feature = "nightly")]
 impl<K, V> Ord for LinearMap<K, V> where K: Ord, V: Ord {
-    fn cmp(&self, other: &Self) -> Ordering { iter::order::cmp(self.iter(), other.iter()) }
+    fn cmp(&self, other: &Self) -> Ordering { self.iter().cmp(other.iter()) }
 }
 
 /// A view into a single occupied location in a LinearMap.


### PR DESCRIPTION
We are using LinearMap in [Collenchyma](https://github.com/autumnai/collenchyma) und the missing Debug flag hinders use from deriving Debug on structs that contain a LinearMap.

I moved Debug out of the nightly feature since they have been stable for quite some time.