### PR TITLE
Remove "unzip the vectors?" TODO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,6 @@ use std::vec;
 
 use self::Entry::{Occupied, Vacant};
 
-// TODO: Unzip the vectors?
-// Consideration: When unzipped, the compiler will not be able to understand
-// that both of the `Vec`s have the same length, thus stuff like `iter` and so
-// on should probably be implemented in unsafe code.
-
 /// A map implemented by searching linearly in a vector.
 ///
 /// `LinearMap`'s keys are compared using the [`Eq`][eq] trait. All search operations


### PR DESCRIPTION
It belongs on the issue tracker.

Pros:
- No need for custom keys and values iterators.
- Drop the values and convert into a set without allocating.
- Less padding if K and V have different alignment.

Cons:
- Lots of `unsafe` blocks to match performance.
- Memory fragmentation and cache misses:  
  I think `get()`, `insert()` and `iter()` are used more than `contains()`, `keys()` and `values()`.
- extra work in `clear()`, `reserve()` and similar, especially if we use raw pointers.
- Increased struct size.
