### PR TITLE
A map view of a borrowed slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linear-map"
 version = "1.1.0"
 license = "MIT/Apache-2.0"
-description = "A map implemented by searching linearly in a vector."
+description = "A map implemented by searching linearly in a vector or slice."
 authors = [
     "Andrew Paseltiner <apaseltiner@gmail.com>",
     "Tobias Bucher <tobiasbucher5991@gmail.com>",

--- a/src/borrowed.rs
+++ b/src/borrowed.rs
@@ -1,0 +1,157 @@
+use std::{mem, fmt};
+use std::borrow::{Borrow,ToOwned};
+use super::{LinearMap, Iter,IterMut,Keys,Values};
+
+fn first_duplicate<'a,K,V,I>(iter: I) -> Option<usize>
+where K: Eq+'a, V: 'a, I: Iterator<Item=&'a(K,V)>+Clone {
+    iter.clone().enumerate().filter_map( |(i,&(ref needle,_))|
+        iter.clone().take(i).position( |&(ref key,_)| key == needle )
+    ).next()
+}
+
+pub struct LinearBorrowedMap<K: Eq, V> ( [(K,V)] );
+
+impl<K: Eq, V> LinearBorrowedMap<K, V> {
+    pub fn new(slice: &[(K,V)]) -> Result<&Self, &K> {
+        unsafe{ match first_duplicate(slice.iter()) {
+            None => Ok(Self::new_unchecked(slice)),
+            Some(i) => Err(&slice[i].0),
+        }}
+    }
+    /// Create a map with mutable values without checking for duplicate keys,
+    ///
+    /// This boils down to a transmute, while new takes O(n^2).
+    pub unsafe fn new_unchecked(slice: &[(K,V)]) -> &Self {
+        mem::transmute(slice)
+    }
+    pub fn new_mut(slice: &mut[(K,V)]) -> Result<&mut Self, &mut K> {
+        unsafe{ match first_duplicate(slice.iter()) {
+            None => Ok(Self::new_mut_unchecked(slice)),
+            Some(i) => Err(&mut slice[i].0),
+        }}
+    }
+    /// Create a map with mutable values without checking for duplicate keys,
+    ///
+    /// This boils down to a transmute, while new takes O(n^2).
+    pub unsafe fn new_mut_unchecked(slice: &mut[(K,V)]) -> &mut Self {
+        mem::transmute(slice)
+    }
+
+
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator yielding references to the map's keys and their corresponding values in
+    /// arbitrary order.
+    ///
+    /// The iterator's item type is `(&K, &V)`.
+    pub fn iter(&self) -> Iter<K, V> {
+        Iter { iter: self.0.iter() }
+    }
+
+    /// Returns an iterator yielding references to the map's keys and mutable references to their
+    /// corresponding values in arbitrary order.
+    ///
+    /// The iterator's item type is `(&K, &mut V)`.
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+        IterMut { iter: self.0.iter_mut() }
+    }
+
+    /// Returns an iterator yielding references to the map's keys in arbitrary order.
+    ///
+    /// The iterator's item type is `&K`.
+    pub fn keys(&self) -> Keys<K, V> {
+        Keys { iter: self.iter() }
+    }
+
+    /// Returns an iterator yielding references to the map's values in arbitrary order.
+    ///
+    /// The iterator's item type is `&V`.
+    pub fn values(&self) -> Values<K, V> {
+        Values { iter: self.iter() }
+    }
+
+    /// Checks if the map contains a key that is equal to the given key.
+    ///
+    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
+    /// *must* match that of the key type.
+    pub fn contains_key<Q: ?Sized + Eq>(&self, key: &Q) -> bool
+    where K: Borrow<Q> {
+        self.get(key).is_some()
+    }
+
+    /// Returns a reference to the value in the map whose key is equal to the given key.
+    ///
+    /// Returns `None` if the map contains no such key.
+    ///
+    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
+    /// *must* match that of the key type.
+    pub fn get<Q: ?Sized + Eq>(&self, key: &Q) -> Option<&V>
+    where K: Borrow<Q> {
+        self.iter().find(|&e| e.0.borrow() == key ).map(|(_,v)| v )
+    }
+
+    /// Returns a mutable reference to the value in the map whose key is equal to the given key.
+    ///
+    /// Returns `None` if the map contains no such key.
+    ///
+    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
+    /// *must* match that of the key type.
+    pub fn get_mut<Q: ?Sized + Eq>(&mut self, key: &Q) -> Option<&mut V>
+    where K: Borrow<Q> {
+        self.iter_mut().find(|&(k,_)| k.borrow() == key ).map(|(_,v)| v )
+    }
+}
+
+impl<K: Eq, V> AsRef<[(K,V)]> for LinearBorrowedMap<K,V> {
+    fn as_ref(&self) -> &[(K,V)] {
+        &self.0
+    }
+}
+
+impl<K: Eq+Clone, V: Clone> ToOwned for LinearBorrowedMap<K,V> {
+    type Owned = LinearMap<K,V>;
+    fn to_owned(&self) -> Self::Owned {
+        LinearMap{ storage: self.as_ref().to_vec() }
+    }
+}
+
+impl<'a, K: Eq, V> IntoIterator for &'a LinearBorrowedMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
+impl<'a, K: Eq, V> IntoIterator for &'a mut LinearBorrowedMap<K, V> {
+    type Item = (&'a K, &'a mut V);
+    type IntoIter = IterMut<'a, K, V>;
+
+    fn into_iter(self) -> IterMut<'a, K, V> {
+        self.iter_mut()
+    }
+}
+
+impl<K: Eq+fmt::Debug, V: fmt::Debug> fmt::Debug for LinearBorrowedMap<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_map().entries(self).finish()
+    }
+}
+
+impl<K: Eq, V: PartialEq> PartialEq for LinearBorrowedMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+        && self.iter().all(|(k, v)| other.get(k) == Some(v) )
+    }
+}
+
+impl<K: Eq, V: Eq> Eq for LinearBorrowedMap<K, V>
+    {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,22 @@
-//! A map implemented by searching linearly in a vector.
+//! A map implemented by searching linearly in a vector or slice.
 //!
 //! See the [`LinearMap`](struct.LinearMap.html) type for details.
 
 #![deny(missing_docs)]
 
+mod borrowed;
 // Optional Serde support
 #[cfg(feature = "serde_impl")]
 pub mod serde;
 
-use std::borrow::Borrow;
+use std::borrow::{Borrow, BorrowMut};
 use std::fmt::{self, Debug};
 use std::iter;
 use std::mem;
 use std::ops;
 use std::slice;
 use std::vec;
-
+use borrowed::LinearBorrowedMap;
 use self::Entry::{Occupied, Vacant};
 
 // TODO: Unzip the vectors?
@@ -130,16 +131,6 @@ impl<K: Eq, V> LinearMap<K, V> {
         self.storage.shrink_to_fit();
     }
 
-    /// Returns the number of elements in the map.
-    pub fn len(&self) -> usize {
-        self.storage.len()
-    }
-
-    /// Returns true if the map contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.storage.is_empty()
-    }
-
     /// Clears the map, removing all elements. Keeps the allocated memory for
     /// reuse.
     pub fn clear(&mut self) {
@@ -155,74 +146,6 @@ impl<K: Eq, V> LinearMap<K, V> {
     /// The iterator's item type is `(K, V)`.
     pub fn drain(&mut self) -> Drain<K, V> {
         Drain { iter: self.storage.drain(..) }
-    }
-
-    /// Returns an iterator yielding references to the map's keys and their corresponding values in
-    /// arbitrary order.
-    ///
-    /// The iterator's item type is `(&K, &V)`.
-    pub fn iter(&self) -> Iter<K, V> {
-        Iter { iter: self.storage.iter() }
-    }
-
-    /// Returns an iterator yielding references to the map's keys and mutable references to their
-    /// corresponding values in arbitrary order.
-    ///
-    /// The iterator's item type is `(&K, &mut V)`.
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
-        IterMut { iter: self.storage.iter_mut() }
-    }
-
-    /// Returns an iterator yielding references to the map's keys in arbitrary order.
-    ///
-    /// The iterator's item type is `&K`.
-    pub fn keys(&self) -> Keys<K, V> {
-        Keys { iter: self.iter() }
-    }
-
-    /// Returns an iterator yielding references to the map's values in arbitrary order.
-    ///
-    /// The iterator's item type is `&V`.
-    pub fn values(&self) -> Values<K, V> {
-        Values { iter: self.iter() }
-    }
-
-    /// Returns a reference to the value in the map whose key is equal to the given key.
-    ///
-    /// Returns `None` if the map contains no such key.
-    ///
-    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
-    /// *must* match that of the key type.
-    pub fn get<Q: ?Sized + Eq>(&self, key: &Q) -> Option<&V> where K: Borrow<Q> {
-        for (k, v) in self {
-            if key == k.borrow() {
-                return Some(v);
-            }
-        }
-        None
-    }
-
-    /// Returns a mutable reference to the value in the map whose key is equal to the given key.
-    ///
-    /// Returns `None` if the map contains no such key.
-    ///
-    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
-    /// *must* match that of the key type.
-    pub fn get_mut<Q: ?Sized + Eq>(&mut self, key: &Q) -> Option<&mut V> where K: Borrow<Q> {
-        for (k, v) in self {
-            if key == k.borrow() {
-                return Some(v);
-            }
-        }
-        None
-    }
-
-    /// Checks if the map contains a key that is equal to the given key.
-    ///
-    /// The given key may be any borrowed form of the map's key type, but `Eq` on the borrowed form
-    /// *must* match that of the key type.
-    pub fn contains_key<Q: ?Sized + Eq>(&self, key: &Q) -> bool where K: Borrow<Q> {
-        self.get(key).is_some()
     }
 
     /// Inserts a key-value pair into the map.
@@ -319,25 +242,61 @@ impl<'a, K: Eq + Borrow<Q>, V, Q: ?Sized + Eq> ops::Index<&'a Q> for LinearMap<K
 
 impl<K: Eq, V: PartialEq> PartialEq for LinearMap<K, V> {
     fn eq(&self, other: &Self) -> bool {
-        if self.len() != other.len() {
-            return false;
-        }
-
-        for (key, value) in self {
-            if other.get(key) != Some(value) {
-                return false;
-            }
-        }
-
-        true
+        self.len() == other.len()  &&
+        self.iter().find(|&(k,v)| other.get(k) != Some(v) ).is_none()
     }
 }
 
 impl<K: Eq, V: Eq> Eq for LinearMap<K, V> {}
 
+impl<K: Eq, V: PartialEq> PartialEq<LinearBorrowedMap<K, V>> for LinearMap<K, V> {
+    fn eq(&self, other: &LinearBorrowedMap<K, V>) -> bool {
+        &*self == other
+    }
+}
+
+impl<K: Eq, V: PartialEq> PartialEq<LinearMap<K, V>> for LinearBorrowedMap<K, V> {
+    fn eq(&self, other: &LinearMap<K, V>) -> bool {
+        self == &*other
+    }
+}
+
 impl<K: Eq, V> Into<Vec<(K, V)>> for LinearMap<K, V> {
     fn into(self) -> Vec<(K, V)> {
         self.storage
+    }
+}
+
+impl<K: Eq, V> AsRef<LinearBorrowedMap<K, V>> for LinearMap<K, V> {
+    fn as_ref(&self) -> &LinearBorrowedMap<K, V> {
+        unsafe{ LinearBorrowedMap::new_unchecked(&self.storage[..]) }
+    }
+}
+impl<K: Eq, V> Borrow<LinearBorrowedMap<K, V>> for LinearMap<K, V> {
+    fn borrow(&self) -> &LinearBorrowedMap<K, V> {
+        self.as_ref()
+    }
+}
+impl<K: Eq, V> ops::Deref for LinearMap<K, V> {
+    type Target = LinearBorrowedMap<K, V>;
+    fn deref(&self) -> &LinearBorrowedMap<K, V> {
+        self.as_ref()
+    }
+}
+
+impl<K: Eq, V> AsMut<LinearBorrowedMap<K, V>> for LinearMap<K, V> {
+    fn as_mut(&mut self) -> &mut LinearBorrowedMap<K, V> {
+        unsafe{ LinearBorrowedMap::new_mut_unchecked(&mut self.storage[..]) }
+    }
+}
+impl<K: Eq, V> BorrowMut<LinearBorrowedMap<K, V>> for LinearMap<K, V> {
+    fn borrow_mut(&mut self) -> &mut LinearBorrowedMap<K, V> {
+        self.as_mut()
+    }
+}
+impl<K: Eq, V> ops::DerefMut for LinearMap<K, V> {
+    fn deref_mut(&mut self) -> &mut LinearBorrowedMap<K, V> {
+        self.as_mut()
     }
 }
 


### PR DESCRIPTION
LinearMap dereferences to it, and all methods that doesn't structurally modify the map has been moved.

This need some more documentation, but I'd like some feedback before I do any more.

If `LinearSet` is added, this should also add a borrowed variant of it.
