### PR TITLE
Add as_slice functions to map and set with corresponding tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear-map"
-version = "1.2.0"
+version = "1.2.1"
 license = "MIT/Apache-2.0"
 description = "A map implemented by searching linearly in a vector."
 authors = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,13 @@ impl<K: Eq, V> LinearMap<K, V> {
         }
     }
 
+    /// Returns a a slice viewing the map's keys and references in arbitrary order.
+    ///
+    /// The item type is `(K, V)`.
+    pub fn as_slice(&self) -> &[(K, V)] {
+        &self.storage
+    }
+
     /// Returns an iterator yielding references to the map's keys in arbitrary order.
     ///
     /// The iterator's item type is `&K`.

--- a/src/set.rs
+++ b/src/set.rs
@@ -504,6 +504,13 @@ where
     {
         self.map.remove(value).is_some()
     }
+
+    /// Returns a a slice viewing the sets values in arbitrary order.
+    ///
+    /// The item type is `(T, ())`.
+    pub fn as_slice(&self) -> &[(T, ())] {
+        &self.map.storage
+    }
 }
 
 impl<T> PartialEq for LinearSet<T>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -266,6 +266,21 @@ fn test_macro() {
 }
 
 #[test]
+fn test_as_slice() {
+    use linear_map::set::LinearSet;
+    let names = linear_map! {
+        1 => "one",
+        2 => "two",
+    };
+    let slice = names.as_slice();
+    assert_eq!(slice, &[(1, "one"), (2, "two")]);
+    let names: LinearSet<&'static str> = names.into_iter().map(|x| x.1).collect::<LinearSet<_>>();
+    // LinearSet have (T, ()) as items as an implementation detail.
+    let slice = names.as_slice();
+    assert_eq!(slice, &[("one", ()), ("two", ())]);
+}
+
+#[test]
 fn test_retain() {
     let mut map: LinearMap<isize, isize> = (0..100).map(|x| (x, x * 10)).collect();
     map.retain(|&k, _| k % 2 == 0);


### PR DESCRIPTION
I understand there is not much time to review PRs. I hope this change is minimal enough to consider; it would be convenient to view the storage directly with this `as_slice` function.

I have bumped to 1.2.1; I'm happy to add additional cases or documentation if it helps.